### PR TITLE
Fix kodi error

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -36,6 +36,7 @@ def start_info_actions(infos, params):
                 method="Input.SendText",
                 params={"text": params.get("id"), "done": False},
             )
+            return None
         pass_list_to_skin(
             data=listitems,
             handle=params.get("handle", ""),


### PR DESCRIPTION
Without this line it throws this error.
2022-12-18 11:29:05.304 T:3632    ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'UnboundLocalError'>
                                                   Error Contents: local variable 'listitems' referenced before assignment
                                                   Traceback (most recent call last):
                                                     File "C:\Users\Marko\AppData\Roaming\Kodi\addons\plugin.program.autocompletion\plugin.py", line 94, in <module>
                                                       start_info_actions(infos, params)
                                                     File "C:\Users\Marko\AppData\Roaming\Kodi\addons\plugin.program.autocompletion\plugin.py", line 40, in start_info_actions
                                                       data=listitems,
                                                   UnboundLocalError: local variable 'listitems' referenced before assignment
                                                   -->End of Python script error report<--